### PR TITLE
Add --partial to improve the framework performance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,11 +17,6 @@ repos:
       -   id: name-tests-test
       -   id: trailing-whitespace
 
-  - repo: https://github.com/hhatto/autopep8
-    rev: v2.3.1
-    hooks:
-      - id: autopep8
-
   - repo: https://github.com/PyCQA/flake8
     rev: 7.1.1
     hooks:
@@ -40,3 +35,9 @@ repos:
     hooks:
       - id: isort
         args: ["--profile=black"]
+
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.8.0
+    hooks:
+      - id: black
+        language_version: python3

--- a/setup.py
+++ b/setup.py
@@ -3,34 +3,35 @@ from setuptools import find_packages, setup
 
 
 def readme():
-    with open('README.md') as f:
+    with open("README.md") as f:
         return f.read()
 
 
-setup(name='backup-orchestrator',
-      version='1.0.0',
-      description='Backup based on RSYNC command',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      long_description=readme(),
-      classifiers=[
-          'Development Status :: 5 - Production/Stable',
-          'Programming Language :: Python :: 3',
-          'Intended Audience :: End Users/Desktop',
-      ],
-      keywords='backup sync rsync',
-      url='https://github.com/ahestevenz/backup-orchestrator',
-      author='Ariel Hernandez <ahestevenz@bleiben.ar>',
-      author_email='ahestevenz@bleiben.ar',
-      license='Proprietary',
-      install_requires=[
-          'numpy', 'pexpect', 'pytest-shutil', 'loguru', 'pyyaml'
-      ],
-      test_suite='nose.collector',
-      tests_require=['nose'],
-      entry_points={
-          'console_scripts': ['bn-run-backup=backup_orchestrator.scripts.run_backup:main'],
-      },
-      include_package_data=True,
-      zip_safe=True
-      )
+setup(
+    name="backup-orchestrator",
+    version="1.0.1",
+    description="Backup based on RSYNC command",
+    packages=find_packages("src"),
+    package_dir={"": "src"},
+    long_description=readme(),
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Programming Language :: Python :: 3",
+        "Intended Audience :: End Users/Desktop",
+    ],
+    keywords="backup sync rsync",
+    url="https://github.com/ahestevenz/backup-orchestrator",
+    author="Ariel Hernandez <ahestevenz@bleiben.ar>",
+    author_email="ahestevenz@bleiben.ar",
+    license="Proprietary",
+    install_requires=["numpy", "pexpect", "pytest-shutil", "loguru", "pyyaml"],
+    test_suite="nose.collector",
+    tests_require=["nose"],
+    entry_points={
+        "console_scripts": [
+            "bn-run-backup=backup_orchestrator.scripts.run_backup:main"
+        ],
+    },
+    include_package_data=True,
+    zip_safe=True,
+)

--- a/src/backup_orchestrator/backup_orchestrator.py
+++ b/src/backup_orchestrator/backup_orchestrator.py
@@ -49,7 +49,7 @@ class BackupOrchestrator(BaseModel):
     executor: CommandExecutor = Field(default=None, exclude=True)
     backup_directory: Path = Field(default=None)
     verify_backup: bool = Field(default=False)
-    partial: bool = Field(default=False)
+    resume_backup: bool = Field(default=False)
 
     def model_post_init(self, __context: Any) -> None:
         """Perform additional initialization and validation after parsing."""
@@ -67,7 +67,7 @@ class BackupOrchestrator(BaseModel):
         logging.info(
             f"## The directory {self.backup_directory} has been successfully configured.")
         self.executor = CommandExecutor(
-            log_level=self.config.log_level, verify_backup=self.verify_backup, partial=self.partial)
+            log_level=self.config.log_level, verify_backup=self.verify_backup, resume_backup=self.resume_backup)
         self.get_logs_path().mkdir(parents=True, exist_ok=True)
 
     def get_current_backup_path(self) -> Path:
@@ -103,7 +103,7 @@ class BackupOrchestrator(BaseModel):
                     self.backup_directory = Path(
                         self._get_required_setting(settings, "backup_directory"))
                     self.verify_backup = settings.get("verify_backup", False)
-                    self.partial = settings.get("partial", False)
+                    self.resume_backup = settings.get("resume_backup", False)
 
                     # Validate and assign modules
                     modules = config_data.get("modules", {})

--- a/src/backup_orchestrator/backup_orchestrator.py
+++ b/src/backup_orchestrator/backup_orchestrator.py
@@ -49,6 +49,7 @@ class BackupOrchestrator(BaseModel):
     executor: CommandExecutor = Field(default=None, exclude=True)
     backup_directory: Path = Field(default=None)
     verify_backup: bool = Field(default=False)
+    partial: bool = Field(default=False)
 
     def model_post_init(self, __context: Any) -> None:
         """Perform additional initialization and validation after parsing."""
@@ -66,7 +67,7 @@ class BackupOrchestrator(BaseModel):
         logging.info(
             f"## The directory {self.backup_directory} has been successfully configured.")
         self.executor = CommandExecutor(
-            log_level=self.config.log_level, verify_backup=self.verify_backup)
+            log_level=self.config.log_level, verify_backup=self.verify_backup, partial=self.partial)
         self.get_logs_path().mkdir(parents=True, exist_ok=True)
 
     def get_current_backup_path(self) -> Path:
@@ -102,6 +103,7 @@ class BackupOrchestrator(BaseModel):
                     self.backup_directory = Path(
                         self._get_required_setting(settings, "backup_directory"))
                     self.verify_backup = settings.get("verify_backup", False)
+                    self.partial = settings.get("partial", False)
 
                     # Validate and assign modules
                     modules = config_data.get("modules", {})

--- a/src/backup_orchestrator/backup_orchestrator.py
+++ b/src/backup_orchestrator/backup_orchestrator.py
@@ -54,20 +54,13 @@ class BackupOrchestrator(BaseModel):
     def model_post_init(self, __context: Any) -> None:
         """Perform additional initialization and validation after parsing."""
         logging.info("## Welcome to the Backup System Management ##")
-        self._load_backup_info()
-        if not self.backup_directory.exists():
-            try:
-                self.backup_directory.mkdir(parents=True, exist_ok=True)
-            except Exception as e:
-                raise NotADirectoryError(
-                    f"Cannot create the directory {self.backup_directory}. "
-                    "Please check permissions and verify the directory path."
-                ) from e
-
+        self._load_config_and_backup_info()
         logging.info(
             f"## The directory {self.backup_directory} has been successfully configured.")
         self.executor = CommandExecutor(
-            log_level=self.config.log_level, verify_backup=self.verify_backup, resume_backup=self.resume_backup)
+            log_level=self.config.log_level,
+            verify_backup=self.verify_backup,
+            resume_backup=self.resume_backup)
         self.get_logs_path().mkdir(parents=True, exist_ok=True)
 
     def get_current_backup_path(self) -> Path:
@@ -90,7 +83,33 @@ class BackupOrchestrator(BaseModel):
                 f"The '{key}' field is required in the 'settings' section of the configuration file.")
         return value
 
-    def _load_backup_info(self):
+    def _create_backup_directory(self) -> None:
+        if not self.backup_directory.exists():
+            try:
+                self.backup_directory.mkdir(parents=True, exist_ok=True)
+            except Exception as e:
+                raise NotADirectoryError(
+                    f"Cannot create the directory {self.backup_directory}. "
+                    "Please check permissions and verify the directory path."
+                ) from e
+
+    def _retrieve_previous_backup_info(self, current_yaml_file: Path) -> None:
+        previous_config_file = self.get_current_backup_path() / current_yaml_file.name
+        if previous_config_file.exists():
+            with previous_config_file.open() as f:
+                try:
+                    previous_config_data = yaml.safe_load(f)
+                    self.yaml_info["previous"] = BackupModules(
+                        modules=previous_config_data.get("modules", {}))
+                except ValidationError as e:
+                    logging.error(
+                        f"Invalid backup configuration in {previous_config_file}: {e}")
+                    raise
+        else:
+            logging.warning(
+                "No previous backup found; skipping the copy of backup-related files.")
+
+    def _load_config_and_backup_info(self) -> None:
         """Load and validate backup configuration from YAML files."""
         logging.debug("#### Loading YAML file information.")
 
@@ -117,21 +136,9 @@ class BackupOrchestrator(BaseModel):
             logging.warning(
                 "No current YAML file found. Initializing empty modules.")
             self.yaml_info["current"] = BackupModules()
-
-        previous_config_file = self.get_current_backup_path() / current_yaml_file.name
-        if previous_config_file.exists():
-            with previous_config_file.open() as f:
-                try:
-                    previous_config_data = yaml.safe_load(f)
-                    self.yaml_info["previous"] = BackupModules(
-                        modules=previous_config_data.get("modules", {}))
-                except ValidationError as e:
-                    logging.error(
-                        f"Invalid backup configuration in {previous_config_file}: {e}")
-                    raise
-        else:
-            logging.warning(
-                "No previous backup found; skipping the copy of backup-related files.")
+        self._create_backup_directory()
+        self._retrieve_previous_backup_info(
+            current_yaml_file=current_yaml_file)
 
     def _prepare_directory(self, path: Path):
         """Ensure a directory exists."""

--- a/src/backup_orchestrator/backup_orchestrator.py
+++ b/src/backup_orchestrator/backup_orchestrator.py
@@ -13,6 +13,7 @@ from backup_orchestrator.private.command_executor import CommandExecutor, RsyncE
 
 class HostInfo(BaseModel):
     """Represents information about a host for backup."""
+
     user: str
     host: str
     os: str
@@ -27,24 +28,28 @@ class BackupConfig(BaseModel):
     def validate_loglevel(cls, v):
         valid_levels = ["INFO", "DEBUG", "TRACE"]
         if v not in valid_levels:
-            raise ValueError(
-                f"Invalid log_level: {v}. Choose from {valid_levels}")
+            raise ValueError(f"Invalid log_level: {v}. Choose from {valid_levels}")
         return v
 
 
 class BackupModules(BaseModel):
     """Represents the backup configuration from a YAML file."""
+
     modules: Dict[str, HostInfo] = Field(default_factory=dict)
 
 
 class BackupOrchestrator(BaseModel):
     """Pydantic-powered BackupOrchestrator class."""
+
     config: BackupConfig
     yaml_info: Dict[str, BackupModules] = Field(default_factory=dict)
     host_list: List = Field(default_factory=list)
     report: Dict[str, List[str]] = Field(
-        default_factory=lambda: {"successful": [],
-                                 "failed": [], "unreachable_hosts": []}
+        default_factory=lambda: {
+            "successful": [],
+            "failed": [],
+            "unreachable_hosts": [],
+        }
     )
     executor: CommandExecutor = Field(default=None, exclude=True)
     backup_directory: Path = Field(default=None)
@@ -56,11 +61,13 @@ class BackupOrchestrator(BaseModel):
         logging.info("## Welcome to the Backup System Management ##")
         self._load_config_and_backup_info()
         logging.info(
-            f"## The directory {self.backup_directory} has been successfully configured.")
+            f"## The directory {self.backup_directory} has been successfully configured."
+        )
         self.executor = CommandExecutor(
             log_level=self.config.log_level,
             verify_backup=self.verify_backup,
-            resume_backup=self.resume_backup)
+            resume_backup=self.resume_backup,
+        )
         self.get_logs_path().mkdir(parents=True, exist_ok=True)
 
     def get_current_backup_path(self) -> Path:
@@ -80,7 +87,8 @@ class BackupOrchestrator(BaseModel):
         value = settings.get(key)
         if value is None:
             raise ValueError(
-                f"The '{key}' field is required in the 'settings' section of the configuration file.")
+                f"The '{key}' field is required in the 'settings' section of the configuration file."
+            )
         return value
 
     def _create_backup_directory(self) -> None:
@@ -100,14 +108,17 @@ class BackupOrchestrator(BaseModel):
                 try:
                     previous_config_data = yaml.safe_load(f)
                     self.yaml_info["previous"] = BackupModules(
-                        modules=previous_config_data.get("modules", {}))
+                        modules=previous_config_data.get("modules", {})
+                    )
                 except ValidationError as e:
                     logging.error(
-                        f"Invalid backup configuration in {previous_config_file}: {e}")
+                        f"Invalid backup configuration in {previous_config_file}: {e}"
+                    )
                     raise
         else:
             logging.warning(
-                "No previous backup found; skipping the copy of backup-related files.")
+                "No previous backup found; skipping the copy of backup-related files."
+            )
 
     def _load_config_and_backup_info(self) -> None:
         """Load and validate backup configuration from YAML files."""
@@ -120,7 +131,8 @@ class BackupOrchestrator(BaseModel):
                     config_data = yaml.safe_load(f)
                     settings = config_data.get("settings", {})
                     self.backup_directory = Path(
-                        self._get_required_setting(settings, "backup_directory"))
+                        self._get_required_setting(settings, "backup_directory")
+                    )
                     self.verify_backup = settings.get("verify_backup", False)
                     self.resume_backup = settings.get("resume_backup", False)
 
@@ -130,15 +142,14 @@ class BackupOrchestrator(BaseModel):
 
                 except ValidationError as e:
                     logging.error(
-                        f"Invalid backup configuration in {current_yaml_file}: {e}")
+                        f"Invalid backup configuration in {current_yaml_file}: {e}"
+                    )
                     raise
         else:
-            logging.warning(
-                "No current YAML file found. Initializing empty modules.")
+            logging.warning("No current YAML file found. Initializing empty modules.")
             self.yaml_info["current"] = BackupModules()
         self._create_backup_directory()
-        self._retrieve_previous_backup_info(
-            current_yaml_file=current_yaml_file)
+        self._retrieve_previous_backup_info(current_yaml_file=current_yaml_file)
 
     def _prepare_directory(self, path: Path):
         """Ensure a directory exists."""
@@ -149,10 +160,14 @@ class BackupOrchestrator(BaseModel):
         previous_backup_path = self.get_previous_backup_path()
         current_backup_path = self.get_current_backup_path()
 
-        if "previous" in self.yaml_info and self.yaml_info["previous"].modules != self.yaml_info["current"].modules:
+        if (
+            "previous" in self.yaml_info
+            and self.yaml_info["previous"].modules != self.yaml_info["current"].modules
+        ):
             self._prepare_directory(previous_backup_path)
-            missing_modules = set(
-                self.yaml_info["previous"].modules) - set(self.yaml_info["current"].modules)
+            missing_modules = set(self.yaml_info["previous"].modules) - set(
+                self.yaml_info["current"].modules
+            )
             for module in missing_modules:
                 logging.warning(f"## Moving missing module: {module}")
                 src_dir = current_backup_path / module
@@ -162,14 +177,14 @@ class BackupOrchestrator(BaseModel):
                 if src_dir.exists():
                     shutil.move(src_dir, dst_dir)
             shutil.copy(self.config.yaml_file, previous_backup_path)
-            shutil.copy(
-                current_backup_path / "backup_report.log", previous_backup_path)
+            shutil.copy(current_backup_path / "backup_report.log", previous_backup_path)
 
     def _backup_host_configuration(self, host_info: HostInfo):
         """Backup configuration files and home directory for a specific host."""
         home_dir = "home" if host_info.os == "linux" else "Users"
-        host_path = self.get_current_backup_path(
-        ) / f"{host_info.user}-{host_info.host}"
+        host_path = (
+            self.get_current_backup_path() / f"{host_info.user}-{host_info.host}"
+        )
         self._prepare_directory(host_path)
         try:
             # Backup /etc configuration files
@@ -178,8 +193,8 @@ class BackupOrchestrator(BaseModel):
                 cmd = self.executor.get_rsync_command(
                     src=f"{host_info.user}@{host_info.host}:/etc/{file}",
                     dst=host_path / "hosts",
-                    log_file=self.get_logs_path(
-                    ) / f"rsync-output-conf-hosts-{host_info.user}.txt",
+                    log_file=self.get_logs_path()
+                    / f"rsync-output-conf-hosts-{host_info.user}.txt",
                 )
                 self.executor.execute_command(cmd)
 
@@ -189,16 +204,14 @@ class BackupOrchestrator(BaseModel):
             cmd = self.executor.get_rsync_command(
                 src=f"{host_info.user}@{host_info.host}:/{home_dir}/{host_info.user}/.[^.]*",
                 dst=home_conf_path,
-                log_file=self.get_logs_path(
-                ) / f"rsync-output-conf-{host_info.user}.txt",
-                extra_args="--exclude '.Trash' --exclude '.cache'",
+                log_file=self.get_logs_path()
+                / f"rsync-output-conf-{host_info.user}.txt",
+                extra_args=["--exclude", ".Trash", "--exclude", ".cache"],
             )
             self.executor.execute_command(cmd)
         except RsyncError as e:
-            logging.error(
-                f"## Host: {host_info.host} has the following error: \n {e}.")
-            self.report["unreachable_hosts"].append(
-                f" Host {host_info.host}: \n {e}")
+            logging.error(f"## Host: {host_info.host} has the following error: \n {e}.")
+            self.report["unreachable_hosts"].append(f" Host {host_info.host}: \n {e}")
 
     def _write_report(self):
         """Write the current backup report to a log file."""
@@ -206,7 +219,7 @@ class BackupOrchestrator(BaseModel):
         date_format = "%Y%m%d-%H%M%S"
         date_info = datetime.datetime.now().strftime(date_format)
         logging.debug(f"#### Backup date written: {date_info}")
-        with report_file.open('w') as f:
+        with report_file.open("w") as f:
             f.write("Backup Report\n")
             f.write("====================\n\n")
             f.write("\n")
@@ -235,26 +248,26 @@ class BackupOrchestrator(BaseModel):
                 cmd = self.executor.get_rsync_command(
                     src=f"{host_info.user}@{host_info.host}:{host_info.src_path}",
                     dst=self.get_current_backup_path() / module_name,
-                    log_file=self.get_logs_path(
-                    ) / f"rsync-output-{module_name}.txt",
+                    log_file=self.get_logs_path() / f"rsync-output-{module_name}.txt",
                 )
                 self.executor.execute_command(cmd)
                 self.report["successful"].append(
-                    f" {module_name}: {host_info.src_path}")
-                logging.success(
-                    f"## Backup completed for module: {module_name}")
+                    f" {module_name}: {host_info.src_path}"
+                )
+                logging.success(f"## Backup completed for module: {module_name}")
             except RsyncError as e:
                 logging.error(
-                    f"## Module: {module_name}, {host_info.src_path} has the following error: \n {e}.")
-                self.report["failed"].append(
-                    f" {module_name}: {host_info.src_path}")
+                    f"## Module: {module_name}, {host_info.src_path} has the following error: \n {e}."
+                )
+                self.report["failed"].append(f" {module_name}: {host_info.src_path}")
 
         if save_conf:
             unique_hosts = {f"{h.user}@{h.host}" for h in self.host_list}
             for host in unique_hosts:
                 logging.info(f"## Starting backup for host: {host}")
                 host_info = next(
-                    h for h in self.host_list if f"{h.user}@{h.host}" == host)
+                    h for h in self.host_list if f"{h.user}@{h.host}" == host
+                )
                 self._backup_host_configuration(host_info)
 
         shutil.copy(self.config.yaml_file, self.get_current_backup_path())

--- a/src/backup_orchestrator/private/command_executor.py
+++ b/src/backup_orchestrator/private/command_executor.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field, ValidationError, field_validator
 
 class RsyncErrorModel(BaseModel):
     """Model to structure and validate Rsync error details."""
+
     message: str = Field(..., description="A brief error message.")
     return_code: int = Field(..., description="Exit code from rsync.")
     output: str = Field(..., description="Detailed error output from rsync.")
@@ -34,13 +35,15 @@ class RsyncError(Exception):
 class CommandExecutor(BaseModel):
     """Utility class to execute shell commands with real-time progress."""
 
-    log_level: str = Field(
-        "INFO", description="Logging level for the executor.")
+    log_level: str = Field("INFO", description="Logging level for the executor.")
     verify_backup: bool = Field(
-        False, description="Activate checksum verification in the rsync command.")
+        False, description="Activate checksum verification in the rsync command."
+    )
     resume_backup: bool = Field(
-        False, description="If enabled, incomplete files are kept at the destination, \
-        allowing the command to be resumed from where it left off instead of starting from zero.")
+        False,
+        description="If enabled, incomplete files are kept at the destination, \
+        allowing the command to be resumed from where it left off instead of starting from zero.",
+    )
 
     @field_validator("log_level")
     @classmethod
@@ -49,7 +52,8 @@ class CommandExecutor(BaseModel):
         valid_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
         if value.upper() not in valid_levels:
             raise ValueError(
-                f"Invalid log_level: {value}. Valid options are: {valid_levels}")
+                f"Invalid log_level: {value}. Valid options are: {valid_levels}"
+            )
         return value.upper()
 
     def _configure_logging(self):
@@ -58,19 +62,32 @@ class CommandExecutor(BaseModel):
         logging.basicConfig(level=numeric_level)
         logging.debug(f"Logging level set to {self.log_level}")
 
-    def get_rsync_command(self, src: str, dst: Path, log_file: Path, extra_args: str = "") -> str:
+    def get_rsync_command(
+        self, src: str, dst: Path, log_file: Path, extra_args: list[str] = []
+    ) -> list[str]:
         """Construct the rsync command."""
         if self.log_level == "DEBUG":
-            extra_args += " --stats "
+            extra_args.append("--stats")
         if self.verify_backup:
             logging.warning(
-                "Backup verification is enabled; the current backup process may take longer than usual.")
-            extra_args += " --checksum "
+                "Backup verification is enabled; the current backup process may take longer than usual."
+            )
+            extra_args.append("--checksum ")
         if self.resume_backup:
-            extra_args += " --partial "
-        return f"rsync --archive --compress --log-file={log_file} --info=progress2 --delete {extra_args} {src}/ {dst}/"
+            extra_args.append(" --partial ")
+        return [
+            "rsync",
+            "--archive",
+            "--compress",
+            f"--log-file={log_file}",
+            "--info=progress2",
+            "--delete",
+            *extra_args,
+            f"{src}/",
+            f" {dst}/",
+        ]
 
-    def execute_command(self, command: str):
+    def execute_command(self, command: list[str]):
         """Execute a shell command and handle errors."""
         self._configure_logging()
         logging.debug(f"#### Executing command: {command}")
@@ -79,7 +96,6 @@ class CommandExecutor(BaseModel):
                 command,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                shell=True,
                 text=True,
                 bufsize=1,
             )
@@ -93,14 +109,18 @@ class CommandExecutor(BaseModel):
 
             if process.returncode != 0:
                 stderr_output = process.stderr.read() if process.stderr else ""
-                raise RsyncError({
-                    "message": "Command execution failed",
-                    "return_code": process.returncode,
-                    "output": stderr_output.strip(),
-                })
+                raise RsyncError(
+                    {
+                        "message": "Command execution failed",
+                        "return_code": process.returncode,
+                        "output": stderr_output.strip(),
+                    }
+                )
         except subprocess.SubprocessError as e:
-            raise RsyncError({
-                "message": "Subprocess execution failed",
-                "return_code": -1,
-                "output": str(e),
-            }) from e
+            raise RsyncError(
+                {
+                    "message": "Subprocess execution failed",
+                    "return_code": -1,
+                    "output": str(e),
+                }
+            ) from e

--- a/src/backup_orchestrator/private/command_executor.py
+++ b/src/backup_orchestrator/private/command_executor.py
@@ -61,13 +61,13 @@ class CommandExecutor(BaseModel):
     def get_rsync_command(self, src: str, dst: Path, log_file: Path, extra_args: str = "") -> str:
         """Construct the rsync command."""
         if self.log_level == "DEBUG":
-            extra_args += " --stats"
+            extra_args += " --stats "
         if self.verify_backup:
             logging.warning(
                 "Backup verification is enabled; the current backup process may take longer than usual.")
-            extra_args += "--checksum"
+            extra_args += " --checksum "
         if self.partial:
-            extra_args += "--partial"
+            extra_args += " --partial "
         return f"rsync --archive --compress --log-file={log_file} --info=progress2 --delete {extra_args} {src}/ {dst}/"
 
     def execute_command(self, command: str):

--- a/src/backup_orchestrator/private/command_executor.py
+++ b/src/backup_orchestrator/private/command_executor.py
@@ -39,8 +39,8 @@ class CommandExecutor(BaseModel):
     verify_backup: bool = Field(
         False, description="Activate checksum verification in the rsync command.")
     resume_backup: bool = Field(
-        False, description="If enabled, rsync keeps the incomplete file at the destination, \
-        so when you rerun the command, it can resume from where it left off instead of starting from zero.")
+        False, description="If enabled, incomplete files are kept at the destination, \
+        allowing the command to be resumed from where it left off instead of starting from zero.")
 
     @field_validator("log_level")
     @classmethod

--- a/src/backup_orchestrator/private/command_executor.py
+++ b/src/backup_orchestrator/private/command_executor.py
@@ -38,6 +38,9 @@ class CommandExecutor(BaseModel):
         "INFO", description="Logging level for the executor.")
     verify_backup: bool = Field(
         False, description="Activate checksum verification in the rsync command.")
+    partial: bool = Field(
+        False, description="If enabled, rsync keeps the incomplete file at the destination, \
+        so when you rerun the command, it can resume from where it left off instead of starting from zero.")
 
     @field_validator("log_level")
     @classmethod
@@ -63,6 +66,8 @@ class CommandExecutor(BaseModel):
             logging.warning(
                 "Backup verification is enabled; the current backup process may take longer than usual.")
             extra_args += "--checksum"
+        if self.partial:
+            extra_args += "--partial"
         return f"rsync --archive --compress --log-file={log_file} --info=progress2 --delete {extra_args} {src}/ {dst}/"
 
     def execute_command(self, command: str):

--- a/src/backup_orchestrator/private/command_executor.py
+++ b/src/backup_orchestrator/private/command_executor.py
@@ -63,7 +63,7 @@ class CommandExecutor(BaseModel):
             logging.warning(
                 "Backup verification is enabled; the current backup process may take longer than usual.")
             extra_args += "--checksum"
-        return f"rsync --archive --compress --log-file={log_file} --info=progress2 --delete {extra_args} {src} {dst}"
+        return f"rsync --archive --compress --log-file={log_file} --info=progress2 --delete {extra_args} {src}/ {dst}/"
 
     def execute_command(self, command: str):
         """Execute a shell command and handle errors."""

--- a/src/backup_orchestrator/private/command_executor.py
+++ b/src/backup_orchestrator/private/command_executor.py
@@ -38,7 +38,7 @@ class CommandExecutor(BaseModel):
         "INFO", description="Logging level for the executor.")
     verify_backup: bool = Field(
         False, description="Activate checksum verification in the rsync command.")
-    partial: bool = Field(
+    resume_backup: bool = Field(
         False, description="If enabled, rsync keeps the incomplete file at the destination, \
         so when you rerun the command, it can resume from where it left off instead of starting from zero.")
 
@@ -66,7 +66,7 @@ class CommandExecutor(BaseModel):
             logging.warning(
                 "Backup verification is enabled; the current backup process may take longer than usual.")
             extra_args += " --checksum "
-        if self.partial:
+        if self.resume_backup:
             extra_args += " --partial "
         return f"rsync --archive --compress --log-file={log_file} --info=progress2 --delete {extra_args} {src}/ {dst}/"
 

--- a/src/backup_orchestrator/private/command_executor.py
+++ b/src/backup_orchestrator/private/command_executor.py
@@ -83,8 +83,8 @@ class CommandExecutor(BaseModel):
             "--info=progress2",
             "--delete",
             *extra_args,
-            f"{src}/",
-            f" {dst}/",
+            src,
+            dst.as_posix(),
         ]
 
     def execute_command(self, command: list[str]):
@@ -97,6 +97,7 @@ class CommandExecutor(BaseModel):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                shell=False,
                 bufsize=1,
             )
             if process.stdout:


### PR DESCRIPTION
- --partial → keeps partially transferred files if interrupted, so transfers resume faster
- [Reverted] Trailing slashes on {src}/ and {dst}/ → makes rsync copy contents of src into dst, not the folder itself 